### PR TITLE
meta: Use universal(all-in-one) image instead of rust image for devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,45 +1,24 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.194.3/containers/debian/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/blob/v0.202.5/containers/codespaces-linux/.devcontainer/base.Dockerfile
+FROM mcr.microsoft.com/vscode/devcontainers/universal:1-linux
 
-# [Choice] Debian version: bullseye, buster, stretch
-ARG VARIANT="bullseye"
-FROM mcr.microsoft.com/vscode/devcontainers/rust:1-${VARIANT}
+USER root
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get -y install --no-install-recommends build-essential make curl bash zsh fish direnv && \
     apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# rust
+# rust-components
 RUN rustup component add rust-src && \
     rustup component add rust-analysis && \
     rustup component add rls
 
-# docker-cli
-RUN apt-get update && \
-    apt-get -y install --no-install-recommends apt-transport-https ca-certificates curl gnupg lsb-release && \
-    curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
-    apt-get update && apt-get -y install docker-ce-cli && \
-    apt-get clean -y && rm -rf /var/lib/apt/lists/*
-
-# nodejs and npm
-RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash - && apt install -y nodejs && \
-    apt-get clean -y && rm -rf /var/lib/apt/lists/*
-
-# golang
-ENV GOPATH /go
-ENV GOROOT /usr/local/go
-ENV PATH $PATH:$GOROOT/bin:$GOPATH/bin
-RUN curl -sLo go.tar.gz https://golang.org/dl/go1.17.2.linux-amd64.tar.gz && \
-    rm -rf /usr/local/go && tar -C /usr/local -xzf go.tar.gz && \
-    mkdir -p $GOPATH
-
-# grpcurl
-RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
-
 # diesel
 RUN apt-get update && apt-get -y install --no-install-recommends libpq-dev && \
     apt-get clean -y && rm -rf /var/lib/apt/lists/* && \
-    cargo install diesel_cli --features postgres
+    cargo install diesel_cli --no-default-features --features postgres
+
+# grpcurl
+RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
 
 # yarn
 RUN npm install -g yarn

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,11 +8,25 @@
 
   // Set *default* container specific settings.json values on container create.
   "settings": {
+    "go.toolsManagement.checkForUpdates": "local",
+    "go.useLanguageServer": true,
+    "go.gopath": "/go",
+    "go.goroot": "/usr/local/go",
+    "python.pythonPath": "/opt/python/latest/bin/python",
+    "python.linting.enabled": true,
+    "python.linting.pylintEnabled": true,
+    "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+    "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+    "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+    "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+    "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+    "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+    "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+    "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+    "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+    "lldb.executable": "/usr/bin/lldb",
     "files.watcherExclude": {
       "**/target/**": true
-    },
-    "[rust]": {
-      "editor.defaultFormatter": "rust-lang.rust"
     },
     "rust.target_dir": "/cache/target",
     "sqltools.connections": [
@@ -44,5 +58,5 @@
   ]
 
   // More info: https://aka.ms/vscode-remote/containers/non-root.
-  // "remoteUser": "vscode"
+  // "remoteUser": "codespace",
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
-      args:
-        - VARIANT=bullseye
     environment:
       - CARGO_BUILD_TARGET_DIR=/cache/target
       - DATABASE_URL=postgres://postgres:postgres@localhost/peta
@@ -19,6 +17,8 @@ services:
       - SYS_PTRACE
     security_opt:
       - seccomp:unconfined
+    privileged: true
+    init: true
 
   db:
     image: postgres:latest


### PR DESCRIPTION
## summary

- [x] Use mcr.microsoft.com/vscode/devcontainers/universal:linux
  - https://github.com/microsoft/vscode-dev-containers/tree/main/containers/codespaces-linux#summary
- [x] Update devcontainer.json inspired by https://github.com/microsoft/vscode-dev-containers/blob/main/containers/codespaces-linux/.devcontainer/devcontainer.json