### PR TITLE
backend/fusen: Rename database to separate by microservices

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: .devcontainer/Dockerfile
     environment:
       - CARGO_BUILD_TARGET_DIR=/cache/target
-      - DATABASE_URL=postgres://postgres:postgres@localhost/peta
+      - FUSEN_DATABASE_URL=postgres://postgres:postgres@localhost/fusen
     tty: true
     working_dir: /workspace
     volumes:

--- a/.envrc.example
+++ b/.envrc.example
@@ -1,1 +1,1 @@
-export DATABASE_URL=postgres://postgres:postgres@localhost/peta
+export FUSEN_DATABASE_URL=postgres://postgres:postgres@localhost/fusen

--- a/.github/workflows/fusen.yml
+++ b/.github/workflows/fusen.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: peta_test
+          POSTGRES_DB: postgres
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v2
@@ -67,8 +67,14 @@ jobs:
           restore-keys: ${{ runner.os }}-sccache-
       - name: Start sccache server
         run: sccache --start-server
+      - name: Install libpq for diesel-cli
+        run: sudo apt-get -y install --no-install-recommends libpq-dev
+      - name: Install diesel-cli
+        run: cargo install diesel_cli --no-default-features --features postgres
       - name: Build
         run: cargo build
+      - name: Migrate database
+        run: make db_test
       - name: Run tests
         run: cargo test --workspace
       - name: Print sccache stats

--- a/backend/fusen/Makefile
+++ b/backend/fusen/Makefile
@@ -1,7 +1,7 @@
 SHELL = /bin/bash
 
-DATABASE_URL ?= postgres://postgres:postgres@localhost/peta
-TEST_DATABASE_URL ?= postgres://postgres:postgres@localhost/peta_test
+FUSEN_DATABASE_URL ?= postgres://postgres:postgres@localhost/fusen
+FUSEN_TEST_DATABASE_URL ?= postgres://postgres:postgres@localhost/fusen_test
 
 .PHONY: all
 all: fmt lint test
@@ -20,15 +20,15 @@ test: db_test
 
 .PHONY: db
 db:
-	@diesel --database-url ${DATABASE_URL} setup
-	@diesel --database-url ${DATABASE_URL} migration run
-	@diesel --database-url ${DATABASE_URL} migration list
+	@diesel --database-url ${FUSEN_DATABASE_URL} setup
+	@diesel --database-url ${FUSEN_DATABASE_URL} migration run
+	@diesel --database-url ${FUSEN_DATABASE_URL} migration list
 
 .PHONY: db_test
 db_test:
-	@diesel --database-url ${TEST_DATABASE_URL} setup
-	@diesel --database-url ${TEST_DATABASE_URL} migration run
-	@diesel --database-url ${TEST_DATABASE_URL} migration list
+	@diesel --database-url ${FUSEN_TEST_DATABASE_URL} setup
+	@diesel --database-url ${FUSEN_TEST_DATABASE_URL} migration run
+	@diesel --database-url ${FUSEN_TEST_DATABASE_URL} migration list
 
 .PHONY: run
 run:

--- a/backend/fusen/infrastructure/src/postgres/fusen.rs
+++ b/backend/fusen/infrastructure/src/postgres/fusen.rs
@@ -90,7 +90,7 @@ mod tests {
 
     #[test]
     fn test_fusen_repository_create() {
-        let database_url = "postgres://postgres:postgres@localhost/peta_test";
+        let database_url = "postgres://postgres:postgres@localhost/fusen_test";
         let connections = DbPool::new(database_url);
 
         init(connections.clone());
@@ -114,7 +114,7 @@ mod tests {
 
     #[test]
     fn test_fusen_repository_get() {
-        let database_url = "postgres://postgres:postgres@localhost/peta_test";
+        let database_url = "postgres://postgres:postgres@localhost/fusen_test";
         let connections = DbPool::new(database_url);
 
         init(connections.clone());
@@ -139,7 +139,7 @@ mod tests {
 
     #[test]
     fn test_fusen_repository_delete() {
-        let database_url = "postgres://postgres:postgres@localhost/peta_test";
+        let database_url = "postgres://postgres:postgres@localhost/fusen_test";
         let connections = DbPool::new(database_url);
 
         init(connections.clone());

--- a/backend/fusen/main.rs
+++ b/backend/fusen/main.rs
@@ -11,7 +11,7 @@ use usecase::interactor::GetFusenInteractor;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let database_url = env::var("FUSEN_DATABASE_URL").expect("FUSEN_DATABASE_URL must be set");
 
     let connections = DbPool::new(&database_url);
 


### PR DESCRIPTION
## summary

- [x] backend/fusen: Rename database to separate by microservices
  - peta -> fusen
  - peta_test -> fusen_test