### PR TITLE
meta:  share local .gitconfig and .ssh to container launched by docker-compose

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     tty: true
     working_dir: /workspace
     volumes:
+      - ${HOME}/.gitconfig:/root/.gitconfig:ro
+      - ${HOME}/.ssh:/root/.ssh:ro
       - ..:/workspace:delegated
       - cache-rust-target:/cache/target
     network_mode: service:db


### PR DESCRIPTION
* devcontainerが起動したcontainerにlocalの.sshや.gitconfigをマウントする
* ![image](https://user-images.githubusercontent.com/5450941/139272171-fc341a8a-7512-4976-a486-f68d9efb5ba6.png)
* working expectedly