### PR TITLE
meta: Update rust edition to 2021

### DIFF
--- a/backend/fusen/Cargo.toml
+++ b/backend/fusen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fusen"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/backend/fusen/domain/Cargo.toml
+++ b/backend/fusen/domain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "domain"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/backend/fusen/infrastructure/Cargo.toml
+++ b/backend/fusen/infrastructure/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "infrastructure"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/backend/fusen/interface/Cargo.toml
+++ b/backend/fusen/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "interface"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/backend/fusen/usecase/Cargo.toml
+++ b/backend/fusen/usecase/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usecase"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/backend/recommendation/Cargo.toml
+++ b/backend/recommendation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "recommendation"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/backend/recommendation/domain/Cargo.toml
+++ b/backend/recommendation/domain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "domain"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/backend/recommendation/infrastructure/Cargo.toml
+++ b/backend/recommendation/infrastructure/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "infrastructure"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/backend/recommendation/interface/Cargo.toml
+++ b/backend/recommendation/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "interface"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/backend/recommendation/usecase/Cargo.toml
+++ b/backend/recommendation/usecase/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usecase"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/backend/tag/Cargo.toml
+++ b/backend/tag/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tag"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/backend/tag/domain/Cargo.toml
+++ b/backend/tag/domain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "domain"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/backend/tag/infrastructure/Cargo.toml
+++ b/backend/tag/infrastructure/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "infrastructure"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/backend/tag/interface/Cargo.toml
+++ b/backend/tag/interface/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
 name = "interface"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tonic = "0.6.0"
+prost = "0.9.0"
+
+[build-dependencies]
+tonic-build = "0.6.0"

--- a/backend/tag/interface/Cargo.toml
+++ b/backend/tag/interface/Cargo.toml
@@ -4,10 +4,3 @@ version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-tonic = "0.6.0"
-prost = "0.9.0"
-
-[build-dependencies]
-tonic-build = "0.6.0"


### PR DESCRIPTION
* change rust edition to 2021
* devcontainer用のcontainer imageもrust 1.5.6に対応した
  * https://github.com/microsoft/vscode-dev-containers/blob/main/containers/codespaces-linux/history/1.6.8.md
